### PR TITLE
Disable all Dependabot PRs until further notice

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
   schedule:
     interval: daily
     time: "09:00"
-  open-pull-requests-limit: 10
+  # Disabling all Dependabot PRs until further notice:
+  open-pull-requests-limit: 0
   ignore:
   - dependency-name: io.dropwizard.metrics:metrics-core
     versions:


### PR DESCRIPTION
As this repo is currently neither updated with latest dependencies nor
used by its contributors. Base this interim way of disabling PRs on [1].

[1] https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates#disabling-dependabot-version-updates